### PR TITLE
Batch rename: APGL-3.0 -> AGPL-3.0

### DIFF
--- a/models/object_detection/yolov10/results_yolov10b.json
+++ b/models/object_detection/yolov10/results_yolov10b.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov10b",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/THU-MIG/yolov10",
         "paper_url": "https://arxiv.org/abs/2405.14458",
         "run_parameters": {

--- a/models/object_detection/yolov10/results_yolov10l.json
+++ b/models/object_detection/yolov10/results_yolov10l.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov10l",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/THU-MIG/yolov10",
         "paper_url": "https://arxiv.org/abs/2405.14458",
         "run_parameters": {

--- a/models/object_detection/yolov10/results_yolov10m.json
+++ b/models/object_detection/yolov10/results_yolov10m.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov10m",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/THU-MIG/yolov10",
         "paper_url": "https://arxiv.org/abs/2405.14458",
         "run_parameters": {

--- a/models/object_detection/yolov10/results_yolov10n.json
+++ b/models/object_detection/yolov10/results_yolov10n.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov10n",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/THU-MIG/yolov10",
         "paper_url": "https://arxiv.org/abs/2405.14458",
         "run_parameters": {

--- a/models/object_detection/yolov10/results_yolov10s.json
+++ b/models/object_detection/yolov10/results_yolov10s.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov10s",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/THU-MIG/yolov10",
         "paper_url": "https://arxiv.org/abs/2405.14458",
         "run_parameters": {

--- a/models/object_detection/yolov10/results_yolov10x.json
+++ b/models/object_detection/yolov10/results_yolov10x.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov10x",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/THU-MIG/yolov10",
         "paper_url": "https://arxiv.org/abs/2405.14458",
         "run_parameters": {

--- a/models/object_detection/yolov10/run.py
+++ b/models/object_detection/yolov10/run.py
@@ -17,7 +17,7 @@ from utils import (
 
 MODEL_IDS = ["yolov10n", "yolov10s", "yolov10m", "yolov10b", "yolov10l", "yolov10x"]
 DATASET_DIR = "../../../data/coco-val-2017"
-LICENSE = "APGL-3.0"
+LICENSE = "AGPL-3.0"
 
 GIT_REPO_URL = "https://github.com/THU-MIG/yolov10"
 PAPER_URL = "https://arxiv.org/abs/2405.14458"

--- a/models/object_detection/yolov11/results_yolo11l.json
+++ b/models/object_detection/yolov11/results_yolo11l.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolo11l",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov11/results_yolo11m.json
+++ b/models/object_detection/yolov11/results_yolo11m.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolo11m",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov11/results_yolo11n.json
+++ b/models/object_detection/yolov11/results_yolo11n.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolo11n",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov11/results_yolo11s.json
+++ b/models/object_detection/yolov11/results_yolo11s.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolo11s",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov11/results_yolo11x.json
+++ b/models/object_detection/yolov11/results_yolo11x.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolo11x",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov11/run.py
+++ b/models/object_detection/yolov11/run.py
@@ -18,7 +18,7 @@ from utils import (
 )
 
 MODEL_IDS = ["yolo11n", "yolo11s", "yolo11m", "yolo11l", "yolo11x"]
-LICENSE = "APGL-3.0"
+LICENSE = "AGPL-3.0"
 RUN_PARAMETERS = dict(
     imgsz=640,
     iou=0.7,

--- a/models/object_detection/yolov12/results_yolov12l.json
+++ b/models/object_detection/yolov12/results_yolov12l.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov12l.pt",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/sunsmarterjie/yolov12",
         "paper_url": "https://arxiv.org/abs/2502.12524",
         "run_parameters": {

--- a/models/object_detection/yolov12/results_yolov12m.json
+++ b/models/object_detection/yolov12/results_yolov12m.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov12m.pt",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/sunsmarterjie/yolov12",
         "paper_url": "https://arxiv.org/abs/2502.12524",
         "run_parameters": {

--- a/models/object_detection/yolov12/results_yolov12n.json
+++ b/models/object_detection/yolov12/results_yolov12n.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov12n.pt",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/sunsmarterjie/yolov12",
         "paper_url": "https://arxiv.org/abs/2502.12524",
         "run_parameters": {

--- a/models/object_detection/yolov12/results_yolov12s.json
+++ b/models/object_detection/yolov12/results_yolov12s.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov12s.pt",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/sunsmarterjie/yolov12",
         "paper_url": "https://arxiv.org/abs/2502.12524",
         "run_parameters": {

--- a/models/object_detection/yolov12/results_yolov12x.json
+++ b/models/object_detection/yolov12/results_yolov12x.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov12x.pt",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/sunsmarterjie/yolov12",
         "paper_url": "https://arxiv.org/abs/2502.12524",
         "run_parameters": {

--- a/models/object_detection/yolov12/run.py
+++ b/models/object_detection/yolov12/run.py
@@ -27,7 +27,7 @@ MODEL_URLS: dict[str, str] = {
 }
 
 
-LICENSE = "APGL-3.0"
+LICENSE = "AGPL-3.0"
 RUN_PARAMETERS = dict(
     imgsz=640,
     iou=0.7,

--- a/models/object_detection/yolov13/results_yolov13l.pt.json
+++ b/models/object_detection/yolov13/results_yolov13l.pt.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov13l.pt",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/iMoonLab/yolov13",
         "paper_url": "https://arxiv.org/abs/2506.17733",
         "run_parameters": {

--- a/models/object_detection/yolov13/results_yolov13n.pt.json
+++ b/models/object_detection/yolov13/results_yolov13n.pt.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov13n.pt",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/iMoonLab/yolov13",
         "paper_url": "https://arxiv.org/abs/2506.17733",
         "run_parameters": {

--- a/models/object_detection/yolov13/results_yolov13s.pt.json
+++ b/models/object_detection/yolov13/results_yolov13s.pt.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov13s.pt",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/iMoonLab/yolov13",
         "paper_url": "https://arxiv.org/abs/2506.17733",
         "run_parameters": {

--- a/models/object_detection/yolov13/results_yolov13x.pt.json
+++ b/models/object_detection/yolov13/results_yolov13x.pt.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov13x.pt",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/iMoonLab/yolov13",
         "paper_url": "https://arxiv.org/abs/2506.17733",
         "run_parameters": {

--- a/models/object_detection/yolov13/run.py
+++ b/models/object_detection/yolov13/run.py
@@ -19,7 +19,7 @@ from utils import (
 )
 
 MODEL_IDS = ["yolov13n.pt", "yolov13s.pt", "yolov13l.pt", "yolov13x.pt"]
-LICENSE = "APGL-3.0"
+LICENSE = "AGPL-3.0"
 RUN_PARAMETERS = dict(
     imgsz=640,
     iou=0.7,

--- a/models/object_detection/yolov8/results_yolov8l.json
+++ b/models/object_detection/yolov8/results_yolov8l.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov8l",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov8/results_yolov8m.json
+++ b/models/object_detection/yolov8/results_yolov8m.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov8m",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov8/results_yolov8n.json
+++ b/models/object_detection/yolov8/results_yolov8n.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov8n",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov8/results_yolov8s.json
+++ b/models/object_detection/yolov8/results_yolov8s.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov8s",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov8/results_yolov8x.json
+++ b/models/object_detection/yolov8/results_yolov8x.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "model": "yolov8x",
-        "license": "APGL-3.0",
+        "license": "AGPL-3.0",
         "github_url": "https://github.com/ultralytics/ultralytics",
         "paper_url": "",
         "run_parameters": {

--- a/models/object_detection/yolov8/run.py
+++ b/models/object_detection/yolov8/run.py
@@ -18,7 +18,7 @@ from utils import (
 )
 
 MODEL_IDS = ["yolov8n", "yolov8s", "yolov8m", "yolov8l", "yolov8x"]
-LICENSE = "APGL-3.0"
+LICENSE = "AGPL-3.0"
 RUN_PARAMETERS = dict(
     imgsz=640,
     iou=0.7,

--- a/static/aggregate_results.js
+++ b/static/aggregate_results.js
@@ -2,7 +2,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov8l",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -75,7 +75,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov8x",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -148,7 +148,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov8m",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -221,7 +221,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov8s",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -294,7 +294,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov8n",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -1141,7 +1141,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov10s",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/THU-MIG/yolov10",
       "paper_url": "https://arxiv.org/abs/2405.14458",
       "run_parameters": {
@@ -1214,7 +1214,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov10l",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/THU-MIG/yolov10",
       "paper_url": "https://arxiv.org/abs/2405.14458",
       "run_parameters": {
@@ -1287,7 +1287,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov10m",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/THU-MIG/yolov10",
       "paper_url": "https://arxiv.org/abs/2405.14458",
       "run_parameters": {
@@ -1360,7 +1360,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov10x",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/THU-MIG/yolov10",
       "paper_url": "https://arxiv.org/abs/2405.14458",
       "run_parameters": {
@@ -1433,7 +1433,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov10n",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/THU-MIG/yolov10",
       "paper_url": "https://arxiv.org/abs/2405.14458",
       "run_parameters": {
@@ -1506,7 +1506,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov10b",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/THU-MIG/yolov10",
       "paper_url": "https://arxiv.org/abs/2405.14458",
       "run_parameters": {
@@ -1579,7 +1579,7 @@ const results = [
   {
     "metadata": {
       "model": "yolo11l",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -1652,7 +1652,7 @@ const results = [
   {
     "metadata": {
       "model": "yolo11m",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -1725,7 +1725,7 @@ const results = [
   {
     "metadata": {
       "model": "yolo11x",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -1798,7 +1798,7 @@ const results = [
   {
     "metadata": {
       "model": "yolo11s",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -1871,7 +1871,7 @@ const results = [
   {
     "metadata": {
       "model": "yolo11n",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/ultralytics/ultralytics",
       "paper_url": "",
       "run_parameters": {
@@ -3359,7 +3359,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov13x.pt",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/iMoonLab/yolov13",
       "paper_url": "https://arxiv.org/abs/2506.17733",
       "run_parameters": {
@@ -3432,7 +3432,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov13l.pt",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/iMoonLab/yolov13",
       "paper_url": "https://arxiv.org/abs/2506.17733",
       "run_parameters": {
@@ -3505,7 +3505,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov13n.pt",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/iMoonLab/yolov13",
       "paper_url": "https://arxiv.org/abs/2506.17733",
       "run_parameters": {
@@ -3578,7 +3578,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov13s.pt",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/iMoonLab/yolov13",
       "paper_url": "https://arxiv.org/abs/2506.17733",
       "run_parameters": {
@@ -4290,7 +4290,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov12s.pt",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/sunsmarterjie/yolov12",
       "paper_url": "https://arxiv.org/abs/2502.12524",
       "run_parameters": {
@@ -4363,7 +4363,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov12l.pt",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/sunsmarterjie/yolov12",
       "paper_url": "https://arxiv.org/abs/2502.12524",
       "run_parameters": {
@@ -4436,7 +4436,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov12x.pt",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/sunsmarterjie/yolov12",
       "paper_url": "https://arxiv.org/abs/2502.12524",
       "run_parameters": {
@@ -4509,7 +4509,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov12m.pt",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/sunsmarterjie/yolov12",
       "paper_url": "https://arxiv.org/abs/2502.12524",
       "run_parameters": {
@@ -4582,7 +4582,7 @@ const results = [
   {
     "metadata": {
       "model": "yolov12n.pt",
-      "license": "APGL-3.0",
+      "license": "AGPL-3.0",
       "github_url": "https://github.com/sunsmarterjie/yolov12",
       "paper_url": "https://arxiv.org/abs/2502.12524",
       "run_parameters": {

--- a/static/aggregate_results.json
+++ b/static/aggregate_results.json
@@ -2,7 +2,7 @@
     {
         "metadata": {
             "model": "yolov8l",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -75,7 +75,7 @@
     {
         "metadata": {
             "model": "yolov8x",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -148,7 +148,7 @@
     {
         "metadata": {
             "model": "yolov8m",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -221,7 +221,7 @@
     {
         "metadata": {
             "model": "yolov8s",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -294,7 +294,7 @@
     {
         "metadata": {
             "model": "yolov8n",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -1141,7 +1141,7 @@
     {
         "metadata": {
             "model": "yolov10s",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/THU-MIG/yolov10",
             "paper_url": "https://arxiv.org/abs/2405.14458",
             "run_parameters": {
@@ -1214,7 +1214,7 @@
     {
         "metadata": {
             "model": "yolov10l",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/THU-MIG/yolov10",
             "paper_url": "https://arxiv.org/abs/2405.14458",
             "run_parameters": {
@@ -1287,7 +1287,7 @@
     {
         "metadata": {
             "model": "yolov10m",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/THU-MIG/yolov10",
             "paper_url": "https://arxiv.org/abs/2405.14458",
             "run_parameters": {
@@ -1360,7 +1360,7 @@
     {
         "metadata": {
             "model": "yolov10x",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/THU-MIG/yolov10",
             "paper_url": "https://arxiv.org/abs/2405.14458",
             "run_parameters": {
@@ -1433,7 +1433,7 @@
     {
         "metadata": {
             "model": "yolov10n",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/THU-MIG/yolov10",
             "paper_url": "https://arxiv.org/abs/2405.14458",
             "run_parameters": {
@@ -1506,7 +1506,7 @@
     {
         "metadata": {
             "model": "yolov10b",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/THU-MIG/yolov10",
             "paper_url": "https://arxiv.org/abs/2405.14458",
             "run_parameters": {
@@ -1579,7 +1579,7 @@
     {
         "metadata": {
             "model": "yolo11l",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -1652,7 +1652,7 @@
     {
         "metadata": {
             "model": "yolo11m",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -1725,7 +1725,7 @@
     {
         "metadata": {
             "model": "yolo11x",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -1798,7 +1798,7 @@
     {
         "metadata": {
             "model": "yolo11s",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -1871,7 +1871,7 @@
     {
         "metadata": {
             "model": "yolo11n",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/ultralytics/ultralytics",
             "paper_url": "",
             "run_parameters": {
@@ -3359,7 +3359,7 @@
     {
         "metadata": {
             "model": "yolov13x.pt",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/iMoonLab/yolov13",
             "paper_url": "https://arxiv.org/abs/2506.17733",
             "run_parameters": {
@@ -3432,7 +3432,7 @@
     {
         "metadata": {
             "model": "yolov13l.pt",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/iMoonLab/yolov13",
             "paper_url": "https://arxiv.org/abs/2506.17733",
             "run_parameters": {
@@ -3505,7 +3505,7 @@
     {
         "metadata": {
             "model": "yolov13n.pt",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/iMoonLab/yolov13",
             "paper_url": "https://arxiv.org/abs/2506.17733",
             "run_parameters": {
@@ -3578,7 +3578,7 @@
     {
         "metadata": {
             "model": "yolov13s.pt",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/iMoonLab/yolov13",
             "paper_url": "https://arxiv.org/abs/2506.17733",
             "run_parameters": {
@@ -4290,7 +4290,7 @@
     {
         "metadata": {
             "model": "yolov12s.pt",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/sunsmarterjie/yolov12",
             "paper_url": "https://arxiv.org/abs/2502.12524",
             "run_parameters": {
@@ -4363,7 +4363,7 @@
     {
         "metadata": {
             "model": "yolov12l.pt",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/sunsmarterjie/yolov12",
             "paper_url": "https://arxiv.org/abs/2502.12524",
             "run_parameters": {
@@ -4436,7 +4436,7 @@
     {
         "metadata": {
             "model": "yolov12x.pt",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/sunsmarterjie/yolov12",
             "paper_url": "https://arxiv.org/abs/2502.12524",
             "run_parameters": {
@@ -4509,7 +4509,7 @@
     {
         "metadata": {
             "model": "yolov12m.pt",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/sunsmarterjie/yolov12",
             "paper_url": "https://arxiv.org/abs/2502.12524",
             "run_parameters": {
@@ -4582,7 +4582,7 @@
     {
         "metadata": {
             "model": "yolov12n.pt",
-            "license": "APGL-3.0",
+            "license": "AGPL-3.0",
             "github_url": "https://github.com/sunsmarterjie/yolov12",
             "paper_url": "https://arxiv.org/abs/2502.12524",
             "run_parameters": {


### PR DESCRIPTION
# Description

I noticed that the license is misnamed. This is a small fix applied broadly, changing:
* from "A**PG**L"
* to "A**GP**L"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

1. Ran `python -m http.server 8000`
2. Looked at `http://localhost:8000`
3. Filtered for both `agpl` and `apgl`, checking that only the first is present.

## Any specific deployment considerations

None