### PR TITLE
Add paper URLs for RF-DETR

### DIFF
--- a/models/object_detection/rf-detr/results_RF-DETR-L.json
+++ b/models/object_detection/rf-detr/results_RF-DETR-L.json
@@ -4,7 +4,7 @@
         "model": "RF-DETR-L",
         "license": "apache-2.0",
         "github_url": "https://github.com/roboflow/rf-detr",
-        "paper_url": "",
+        "paper_url": "https://arxiv.org/abs/2511.09554",
         "run_parameters": {
             "threshold": 0,
             "resolution": 704,

--- a/models/object_detection/rf-detr/results_RF-DETR-M.json
+++ b/models/object_detection/rf-detr/results_RF-DETR-M.json
@@ -4,7 +4,7 @@
         "model": "RF-DETR-M",
         "license": "apache-2.0",
         "github_url": "https://github.com/roboflow/rf-detr",
-        "paper_url": "",
+        "paper_url": "https://arxiv.org/abs/2511.09554",
         "run_parameters": {
             "threshold": 0,
             "resolution": 576,

--- a/models/object_detection/rf-detr/results_RF-DETR-N.json
+++ b/models/object_detection/rf-detr/results_RF-DETR-N.json
@@ -4,7 +4,7 @@
         "model": "RF-DETR-N",
         "license": "apache-2.0",
         "github_url": "https://github.com/roboflow/rf-detr",
-        "paper_url": "",
+        "paper_url": "https://arxiv.org/abs/2511.09554",
         "run_parameters": {
             "threshold": 0,
             "resolution": 384,

--- a/models/object_detection/rf-detr/results_RF-DETR-S.json
+++ b/models/object_detection/rf-detr/results_RF-DETR-S.json
@@ -4,7 +4,7 @@
         "model": "RF-DETR-S",
         "license": "apache-2.0",
         "github_url": "https://github.com/roboflow/rf-detr",
-        "paper_url": "",
+        "paper_url": "https://arxiv.org/abs/2511.09554",
         "run_parameters": {
             "threshold": 0,
             "resolution": 512,

--- a/models/object_detection/rf-detr/results_RF-DETR-XL.json
+++ b/models/object_detection/rf-detr/results_RF-DETR-XL.json
@@ -4,7 +4,7 @@
         "model": "RF-DETR-XL",
         "license": "PML-1.0",
         "github_url": "https://github.com/roboflow/rf-detr",
-        "paper_url": "",
+        "paper_url": "https://arxiv.org/abs/2511.09554",
         "run_parameters": {
             "threshold": 0,
             "resolution": 700,

--- a/models/object_detection/rf-detr/results_RF-DETR-XXL.json
+++ b/models/object_detection/rf-detr/results_RF-DETR-XXL.json
@@ -4,7 +4,7 @@
         "model": "RF-DETR-XXL",
         "license": "PML-1.0",
         "github_url": "https://github.com/roboflow/rf-detr",
-        "paper_url": "",
+        "paper_url": "https://arxiv.org/abs/2511.09554",
         "run_parameters": {
             "threshold": 0,
             "resolution": 880,

--- a/models/object_detection/yolov11/run.py
+++ b/models/object_detection/yolov11/run.py
@@ -36,7 +36,7 @@ RUN_PARAMETERS = dict(
     verbose=False,
 )
 GIT_REPO_URL = "https://github.com/ultralytics/ultralytics"
-PAPER_URL = ""
+PAPER_URL = "https://arxiv.org/abs/2511.09554"
 
 
 def run_on_image(model, image) -> sv.Detections:

--- a/static/aggregate_results.js
+++ b/static/aggregate_results.js
@@ -1150,7 +1150,7 @@ const results = [
       "model": "RF-DETR-XXL",
       "license": "PML-1.0",
       "github_url": "https://github.com/roboflow/rf-detr",
-      "paper_url": "",
+      "paper_url": "https://arxiv.org/abs/2511.09554",
       "run_parameters": {
         "threshold": 0,
         "resolution": 880,
@@ -1235,7 +1235,7 @@ const results = [
       "model": "RF-DETR-XL",
       "license": "PML-1.0",
       "github_url": "https://github.com/roboflow/rf-detr",
-      "paper_url": "",
+      "paper_url": "https://arxiv.org/abs/2511.09554",
       "run_parameters": {
         "threshold": 0,
         "resolution": 700,
@@ -1320,7 +1320,7 @@ const results = [
       "model": "RF-DETR-N",
       "license": "apache-2.0",
       "github_url": "https://github.com/roboflow/rf-detr",
-      "paper_url": "",
+      "paper_url": "https://arxiv.org/abs/2511.09554",
       "run_parameters": {
         "threshold": 0,
         "resolution": 384,
@@ -1405,7 +1405,7 @@ const results = [
       "model": "RF-DETR-M",
       "license": "apache-2.0",
       "github_url": "https://github.com/roboflow/rf-detr",
-      "paper_url": "",
+      "paper_url": "https://arxiv.org/abs/2511.09554",
       "run_parameters": {
         "threshold": 0,
         "resolution": 576,
@@ -1490,7 +1490,7 @@ const results = [
       "model": "RF-DETR-L",
       "license": "apache-2.0",
       "github_url": "https://github.com/roboflow/rf-detr",
-      "paper_url": "",
+      "paper_url": "https://arxiv.org/abs/2511.09554",
       "run_parameters": {
         "threshold": 0,
         "resolution": 704,
@@ -1575,7 +1575,7 @@ const results = [
       "model": "RF-DETR-S",
       "license": "apache-2.0",
       "github_url": "https://github.com/roboflow/rf-detr",
-      "paper_url": "",
+      "paper_url": "https://arxiv.org/abs/2511.09554",
       "run_parameters": {
         "threshold": 0,
         "resolution": 512,

--- a/static/aggregate_results.json
+++ b/static/aggregate_results.json
@@ -1150,7 +1150,7 @@
             "model": "RF-DETR-XXL",
             "license": "PML-1.0",
             "github_url": "https://github.com/roboflow/rf-detr",
-            "paper_url": "",
+            "paper_url": "https://arxiv.org/abs/2511.09554",
             "run_parameters": {
                 "threshold": 0,
                 "resolution": 880,
@@ -1235,7 +1235,7 @@
             "model": "RF-DETR-XL",
             "license": "PML-1.0",
             "github_url": "https://github.com/roboflow/rf-detr",
-            "paper_url": "",
+            "paper_url": "https://arxiv.org/abs/2511.09554",
             "run_parameters": {
                 "threshold": 0,
                 "resolution": 700,
@@ -1320,7 +1320,7 @@
             "model": "RF-DETR-N",
             "license": "apache-2.0",
             "github_url": "https://github.com/roboflow/rf-detr",
-            "paper_url": "",
+            "paper_url": "https://arxiv.org/abs/2511.09554",
             "run_parameters": {
                 "threshold": 0,
                 "resolution": 384,
@@ -1405,7 +1405,7 @@
             "model": "RF-DETR-M",
             "license": "apache-2.0",
             "github_url": "https://github.com/roboflow/rf-detr",
-            "paper_url": "",
+            "paper_url": "https://arxiv.org/abs/2511.09554",
             "run_parameters": {
                 "threshold": 0,
                 "resolution": 576,
@@ -1490,7 +1490,7 @@
             "model": "RF-DETR-L",
             "license": "apache-2.0",
             "github_url": "https://github.com/roboflow/rf-detr",
-            "paper_url": "",
+            "paper_url": "https://arxiv.org/abs/2511.09554",
             "run_parameters": {
                 "threshold": 0,
                 "resolution": 704,
@@ -1575,7 +1575,7 @@
             "model": "RF-DETR-S",
             "license": "apache-2.0",
             "github_url": "https://github.com/roboflow/rf-detr",
-            "paper_url": "",
+            "paper_url": "https://arxiv.org/abs/2511.09554",
             "run_parameters": {
                 "threshold": 0,
                 "resolution": 512,


### PR DESCRIPTION
This pull request updates metadata for the RF-DETR object detection models and the YOLOv11 runner to include the correct paper URL, ensuring that all references to the RF-DETR models now point to the official arXiv publication. This improves documentation consistency and makes it easier for users to find the relevant research paper.

**Metadata updates for RF-DETR models:**

* Added the official RF-DETR paper URL (`https://arxiv.org/abs/2511.09554`) to all RF-DETR model result JSON files, including `results_RF-DETR-N.json`, `results_RF-DETR-S.json`, `results_RF-DETR-M.json`, `results_RF-DETR-L.json`, `results_RF-DETR-XL.json`, and `results_RF-DETR-XXL.json`. [[1]](diffhunk://#diff-08360b0dd33b44a815be9c64e6f6e6b91cf0476a89eefd8c79611f95c0527963L7-R7) [[2]](diffhunk://#diff-73c5522efde23ee8545b73df3eccde63b4fdeae14c87315cf4500b841701caaeL7-R7) [[3]](diffhunk://#diff-f6427798d16db45f62f4bec450c4c535b3c4cbcc39bceca787c8c7ca6c31e30fL7-R7) [[4]](diffhunk://#diff-e841ae33a74831bc7f9d122b6bbc9f2f32f59f21687ba20a0e19e07ee3523576L7-R7) [[5]](diffhunk://#diff-012c640e1d6b30aed0e6b8f46712610cdf4710eed0a3a01a35ec85cea11d9dd7L7-R7) [[6]](diffhunk://#diff-544d35d93355d128a14a637387f88acd7d8f65ea9bb67c491a24e5208284f00fL7-R7)

* Updated the RF-DETR model entries in both `static/aggregate_results.json` and `static/aggregate_results.js` to include the paper URL for all model variants. [[1]](diffhunk://#diff-c2f3ff339c9aff252f26a213d6a23cb67263d948a3490c96b27c184f4512aa30L1153-R1153) [[2]](diffhunk://#diff-c2f3ff339c9aff252f26a213d6a23cb67263d948a3490c96b27c184f4512aa30L1238-R1238) [[3]](diffhunk://#diff-c2f3ff339c9aff252f26a213d6a23cb67263d948a3490c96b27c184f4512aa30L1323-R1323) [[4]](diffhunk://#diff-c2f3ff339c9aff252f26a213d6a23cb67263d948a3490c96b27c184f4512aa30L1408-R1408) [[5]](diffhunk://#diff-c2f3ff339c9aff252f26a213d6a23cb67263d948a3490c96b27c184f4512aa30L1493-R1493) [[6]](diffhunk://#diff-c2f3ff339c9aff252f26a213d6a23cb67263d948a3490c96b27c184f4512aa30L1578-R1578) [[7]](diffhunk://#diff-3fe4bbda67c8b32c122c98d211f497517320219ceb795153fdf6ca4c14717c6fL1153-R1153) [[8]](diffhunk://#diff-3fe4bbda67c8b32c122c98d211f497517320219ceb795153fdf6ca4c14717c6fL1238-R1238) [[9]](diffhunk://#diff-3fe4bbda67c8b32c122c98d211f497517320219ceb795153fdf6ca4c14717c6fL1323-R1323) [[10]](diffhunk://#diff-3fe4bbda67c8b32c122c98d211f497517320219ceb795153fdf6ca4c14717c6fL1408-R1408) [[11]](diffhunk://#diff-3fe4bbda67c8b32c122c98d211f497517320219ceb795153fdf6ca4c14717c6fL1493-R1493) [[12]](diffhunk://#diff-3fe4bbda67c8b32c122c98d211f497517320219ceb795153fdf6ca4c14717c6fL1578-R1578)

**YOLOv11 runner update:**

* Set the `PAPER_URL` variable in `yolov11/run.py` to reference the RF-DETR arXiv paper, aligning its metadata with the RF-DETR models.